### PR TITLE
refactor: remove Turbopack option from build script in package.json

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,8 +7,6 @@ const nextConfig: NextConfig = {
     optimizeCss: true,
     scrollRestoration: true,
   },
-  // Webpack bundle optimization
-  bundlePagesRouterDependencies: false,
   // Оптимизация webpack
   webpack: (config, { isServer }) => {
     // Исключаем большие зависимости из клиентского bundle'а
@@ -22,21 +20,7 @@ const nextConfig: NextConfig = {
       };
     }
     
-    // Оптимизация размера bundle'а
-    config.optimization = {
-      ...config.optimization,
-    };
-    
     return config;
-  },
-  // Configuration for Turbopack (experimental)
-  turbopack: {
-    rules: {
-      "*.svg": {
-        loaders: ["@svgr/webpack"],
-        as: "*.js",
-      },
-    },
   },
   // Image configuration for external domains
   images: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:turbo": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "prisma generate",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Simplified Next.js configuration by removing experimental and Turbopack-specific settings. No changes to public APIs or user-facing behavior expected.
- Build
  - Updated the build command to use the standard Next.js build (removed the Turbopack flag), aligning builds with default tooling and reducing configuration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->