### PR TITLE
Use useOAuthSignIn; Stripe webhook uses user id; public auth export

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,39 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Chrome, Github, Mail, AlertCircle } from "lucide-react";
+import { useOAuthSignIn } from "@/app/hooks/useOAuthSignIn";
 
 export default function SignInPage() {
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<string | null>(null);
-
-  const handleSignIn = async (provider: string) => {
-    try {
-      // Clear any previous errors
-      setError(null);
-      setIsLoading(provider);
-
-      const result = await signIn(provider, { 
-        callbackUrl: "/dashboard",
-        redirect: false 
-      });
-
-      if (result?.error) {
-        setError("Не удалось войти. Пожалуйста, попробуйте еще раз.");
-      } else if (result?.url) {
-        // Redirect manually if successful
-        window.location.href = result.url;
-      }
-    } catch (err) {
-      setError("Произошла ошибка при входе. Пожалуйста, попробуйте позже.");
-      console.error("Sign in error:", err);
-    } finally {
-      setIsLoading(null);
-    }
-  };
+  const { handleSignIn, error, isLoading } = useOAuthSignIn();
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-muted p-4">

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import { signIn } from "next-auth/react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Chrome, Github, Mail, AlertCircle } from "lucide-react";
+import { useOAuthSignIn } from "@/app/hooks/useOAuthSignIn";
 
 /**
  * Sign-up page for new users.
@@ -26,33 +25,7 @@ import { Chrome, Github, Mail, AlertCircle } from "lucide-react";
  * 4. Auto sign-in after successful registration
  */
 export default function SignUpPage() {
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<string | null>(null);
-
-  const handleSignIn = async (provider: string) => {
-    try {
-      // Clear any previous errors
-      setError(null);
-      setIsLoading(provider);
-
-      const result = await signIn(provider, { 
-        callbackUrl: "/dashboard",
-        redirect: false 
-      });
-
-      if (result?.error) {
-        setError("Не удалось создать аккаунт. Пожалуйста, попробуйте еще раз.");
-      } else if (result?.url) {
-        // Redirect manually if successful
-        window.location.href = result.url;
-      }
-    } catch (err) {
-      setError("Произошла ошибка при регистрации. Пожалуйста, попробуйте позже.");
-      console.error("Sign up error:", err);
-    } finally {
-      setIsLoading(null);
-    }
-  };
+  const { handleSignIn, error, isLoading } = useOAuthSignIn();
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-muted p-4">

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
         if (userId && creditsToAdd > 0) {
             await prisma.user.update({
                 where: {
-                    userId: userId
+                    id: userId
                 },
                 data: {
                     credits: {

--- a/app/hooks/useOAuthSignIn.ts
+++ b/app/hooks/useOAuthSignIn.ts
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Custom hook for OAuth sign-in functionality.
+ * Handles sign-in flow, loading states, and error handling for OAuth providers.
+ * 
+ * @returns {Object} Object containing:
+ *   - handleSignIn: Function to initiate OAuth sign-in
+ *   - error: Current error message or null
+ *   - isLoading: Currently loading provider or null
+ */
+export function useOAuthSignIn() {
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleSignIn = async (provider: string) => {
+    try {
+      // Clear any previous errors
+      setError(null);
+      setIsLoading(provider);
+
+      const result = await signIn(provider, { 
+        callbackUrl: "/dashboard",
+        redirect: false 
+      });
+
+      if (result?.error) {
+        setError("Не удалось войти. Пожалуйста, попробуйте еще раз.");
+      } else if (result?.url) {
+        // Use client-side navigation to preserve state and avoid full page reload
+        router.push(result.url);
+      }
+    } catch (err) {
+      setError("Произошла ошибка при входе. Пожалуйста, попробуйте позже.");
+      console.error("Sign in error:", err);
+    } finally {
+      setIsLoading(null);
+    }
+  };
+
+  return { handleSignIn, error, isLoading };
+}

--- a/docs/OAUTH_PROVIDERS.md
+++ b/docs/OAUTH_PROVIDERS.md
@@ -82,10 +82,23 @@ Please add the required environment variables to your .env file.
 ### Google OAuth
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
 2. Create a new project or select existing
-3. Enable Google+ API
-4. Go to Credentials → Create Credentials → OAuth 2.0 Client ID
-5. Set authorized redirect URI: `https://yourdomain.com/api/auth/callback/google`
-6. Copy Client ID and Client Secret
+3. **Configure OAuth consent screen:**
+   - Navigate to "APIs & Services" → "OAuth consent screen"
+   - Choose User Type (External for public apps, Internal for Google Workspace)
+   - Fill in required fields (App name, User support email, Developer contact)
+   - Add scopes if needed (email, profile are default)
+   - Save and continue
+4. **Enable Google APIs:**
+   - Navigate to "APIs & Services" → "Library"
+   - Search for and enable "Google People API" (required for user profile data)
+   - You may also need to enable other APIs depending on your requirements
+5. **Create OAuth 2.0 Client ID:**
+   - Navigate to "APIs & Services" → "Credentials"
+   - Click "Create Credentials" → "OAuth 2.0 Client ID"
+   - Choose "Web application" as the application type
+   - Add authorized redirect URI: `https://yourdomain.com/api/auth/callback/google`
+   - Click "Create"
+6. Copy the Client ID and Client Secret from the credentials page
 
 ### GitHub OAuth
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers)

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,18 +1,21 @@
 import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import authConfig from "@/auth.config";
 
-// Import NextAuth dynamically to avoid type issues
+// Import NextAuth for Edge Runtime
+// Dynamic import to ensure Edge Runtime compatibility without Prisma adapter
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const NextAuth = require("next-auth").default;
 
-// Create edge-safe auth instance (without Prisma adapter)
-const { auth } = NextAuth({
+// Create Edge-safe auth instance
+// JWT strategy only - no Prisma adapter, no Node-only modules for Edge Runtime compatibility
+export const { auth } = NextAuth({
   session: { strategy: "jwt" },
   ...authConfig,
 });
 
-// Middleware function
-export default auth(async function middleware(req: any) {
+// Middleware function with proper Edge Runtime typing
+export default auth(async function middleware(req: NextRequest & { auth: any }) {
   const isLoggedIn = !!req.auth;
   const isProtectedRoute = req.nextUrl.pathname.startsWith("/dashboard") || 
                           req.nextUrl.pathname.startsWith("/new") ||

--- a/scripts/test-migration.ts
+++ b/scripts/test-migration.ts
@@ -31,6 +31,7 @@ async function testMigration() {
     
     if (missingTables.length > 0) {
       console.error('❌ Отсутствуют таблицы:', missingTables)
+      await prisma.$disconnect()
       process.exit(1)
     }
     console.log('✅ Все необходимые таблицы существуют\n')
@@ -94,6 +95,7 @@ async function testMigration() {
       )
       if (!found) {
         console.error(`❌ Отсутствует FK: ${expected.table}.${expected.column} → ${expected.refTable}.${expected.refColumn}`)
+        await prisma.$disconnect()
         process.exit(1)
       }
     }
@@ -119,6 +121,7 @@ async function testMigration() {
     })
     if (!foundUser) {
       console.error('❌ Не удалось найти созданного пользователя')
+      await prisma.$disconnect()
       process.exit(1)
     }
     console.log('✅ Чтение User работает')
@@ -130,6 +133,7 @@ async function testMigration() {
     })
     if (updatedUser.credits !== 10) {
       console.error('❌ Обновление не применилось')
+      await prisma.$disconnect()
       process.exit(1)
     }
     console.log('✅ Обновление User работает')
@@ -143,6 +147,7 @@ async function testMigration() {
     })
     if (deletedUser) {
       console.error('❌ Пользователь не удален')
+      await prisma.$disconnect()
       process.exit(1)
     }
     console.log('✅ Удаление User работает\n')
@@ -164,6 +169,7 @@ async function testMigration() {
         }
       })
       console.error('❌ Уникальность email не работает!')
+      await prisma.$disconnect()
       process.exit(1)
     } catch (error: any) {
       if (error.code === 'P2002') {
@@ -188,6 +194,7 @@ async function testMigration() {
     
     if (columnNames.includes('userId')) {
       console.error('❌ Старое поле userId все еще существует!')
+      await prisma.$disconnect()
       process.exit(1)
     }
     console.log('✅ Старое поле userId успешно удалено\n')
@@ -207,6 +214,7 @@ async function testMigration() {
 
   } catch (error) {
     console.error('\n❌ ОШИБКА ПРИ ПРОВЕРКЕ:', error)
+    await prisma.$disconnect()
     process.exit(1)
   } finally {
     await prisma.$disconnect()


### PR DESCRIPTION
…gn-up pages

fix: update userId reference in Stripe webhook handler
fix: ensure user creation handles missing email in checkUser function
docs: enhance Google OAuth setup instructions in documentation
chore: improve error handling in test migration script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified OAuth sign-in across sign-in/sign-up pages with a shared hook, improving loading states and localized error messages.
- Bug Fixes
  - Ensures user accounts are created even when OAuth providers don’t supply an email.
  - Corrects Stripe crediting by targeting the proper user identifier.
- Documentation
  - Updated Google and GitHub OAuth setup steps with current console flows and clearer guidance.
- Chores
  - Improved middleware typing/export for edge compatibility.
  - Ensured database connections are cleanly closed in migration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->