### PR TITLE
Add videos cache tag revalidation and /api/revalidate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 Формат основан на [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 и проект придерживается [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6] - 2025-10-14
+
+### Исправлено
+- **Dashboard: Новое видео теперь отображается сразу после создания без необходимости ручного обновления страницы**
+  - Добавлена инвалидация кэша `revalidateTag('videos')` после создания нового видео в `createVideo`
+  - Создан API endpoint `/api/revalidate` для инвалидации кэша из воркера
+  - Добавлена утилита `revalidateCacheFromWorker` для вызова из контекста Node.js процесса
+  - Воркер теперь инвалидирует кэш после успешного завершения или финальной ошибки видео
+  - Добавлена инвалидация кэша при удалении видео
+  - **Исправлена ошибка:** `"Invariant: static generation store missing in revalidateTag"` при вызове из воркера
+    - `revalidateTag` работает только в контексте Next.js Server Actions
+    - Решение: HTTP запрос к API endpoint вместо прямого вызова `revalidateTag`
+  - Решена проблема с `unstable_cache` который кэшировал список видео на 30 секунд
+  - Теперь после редиректа на дашборд видео отображается мгновенно
+  - Файлы: `app/actions/create.ts`, `app/actions/render.ts`, `app/lib/deleteVideo.ts`, 
+    `app/api/revalidate/route.ts`, `lib/revalidate.ts`, `worker/worker.ts`
+
 ## [1.6.5] - 2025-10-14
 
 ### Исправлено

--- a/app/actions/create.ts
+++ b/app/actions/create.ts
@@ -24,6 +24,7 @@ import { randomUUID } from "crypto"
 import { prisma } from "../lib/db"
 import { videoQueue } from "../lib/queue"
 import { logger } from "@/lib/logger"
+import { revalidateTag } from "next/cache"
 
 /**
  * Валидирует и очищает входной промпт для создания видео
@@ -217,6 +218,9 @@ export const createVideo = async (prompt: string, imageModel?: string) => {
       jobId: job.id,
       executionTime
     });
+
+    // Инвалидируем кэш видео для немедленного отображения нового видео в дашборде
+    revalidateTag('videos');
 
     return {
       videoId,

--- a/app/actions/render.ts
+++ b/app/actions/render.ts
@@ -48,6 +48,10 @@ export const renderVideo = async (videoId: string) => {
                     data: { videoUrl, processing: false }
                 })
 
+                // Примечание: revalidateTag не используется здесь, так как эта функция
+                // вызывается из воркера (вне контекста Next.js Server Actions)
+                // Кэш будет обновлен при создании видео или при ручном обновлении дашборда
+
                 return videoUrl;
             }
 

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+import { logger } from '@/lib/logger';
+
+/**
+ * API endpoint для инвалидации кэша
+ * Используется воркером для обновления кэша после завершения обработки видео
+ * 
+ * POST /api/revalidate
+ * Body: { tag: string, secret?: string }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { tag, secret } = body;
+
+    // Опциональная защита через secret (можно добавить переменную окружения)
+    const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
+    if (REVALIDATE_SECRET && secret !== REVALIDATE_SECRET) {
+      logger.warn('Revalidate: unauthorized attempt', { tag });
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    if (!tag || typeof tag !== 'string') {
+      return NextResponse.json(
+        { error: 'Tag is required and must be a string' },
+        { status: 400 }
+      );
+    }
+
+    // Инвалидируем кэш по тегу
+    revalidateTag(tag);
+
+    logger.info('Cache revalidated successfully', { tag });
+
+    return NextResponse.json({
+      revalidated: true,
+      tag,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    logger.error('Revalidate error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/lib/deleteVideo.ts
+++ b/app/lib/deleteVideo.ts
@@ -2,7 +2,7 @@
 
 import { auth } from "@/auth";
 import { prisma } from "./db";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 
 export async function deleteVideo(videoId: string) {
     try {
@@ -17,6 +17,7 @@ export async function deleteVideo(videoId: string) {
         })
 
         revalidatePath('/dashboard')
+        revalidateTag('videos')
 
         return { success: true }
     } catch {

--- a/docs/CACHE_REVALIDATION.md
+++ b/docs/CACHE_REVALIDATION.md
@@ -1,0 +1,222 @@
+# Cache Revalidation Architecture
+
+## Проблема
+
+При создании нового видео оно не отображалось в дашборде до ручного обновления страницы из-за кэширования в Next.js.
+
+### Техническая причина
+
+В дашборде используется `unstable_cache` с тегом `'videos'` и временем кэширования 30 секунд:
+
+```typescript
+const getCachedVideos = unstable_cache(
+  async (userId: string) => {
+    return await prisma.video.findMany({...});
+  },
+  ['user-videos'],
+  {
+    revalidate: 30,
+    tags: ['videos'],
+  }
+);
+```
+
+После создания видео и редиректа на дашборд, старый кэш все еще актуален.
+
+## Решение
+
+### 1. Инвалидация кэша в Server Actions
+
+В контексте Server Actions можно напрямую использовать `revalidateTag`:
+
+**Места применения:**
+- `app/actions/create.ts` - после создания видео
+- `app/lib/deleteVideo.ts` - после удаления видео
+
+```typescript
+import { revalidateTag } from 'next/cache';
+
+// После изменения данных
+await prisma.video.create({...});
+revalidateTag('videos');
+```
+
+### 2. Инвалидация кэша из воркера
+
+**Проблема:** `revalidateTag` не работает в воркере
+
+Воркер работает как отдельный Node.js процесс, вне контекста Next.js Server Actions. При попытке вызвать `revalidateTag` возникает ошибка:
+
+```
+Error: Invariant: static generation store missing in revalidateTag videos
+```
+
+**Решение:** API endpoint для инвалидации кэша
+
+#### Шаг 1: API Route Handler
+
+Создан endpoint `app/api/revalidate/route.ts`:
+
+```typescript
+import { revalidateTag } from 'next/cache';
+
+export async function POST(request: NextRequest) {
+  const { tag, secret } = await request.json();
+  
+  // Опциональная защита
+  if (REVALIDATE_SECRET && secret !== REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  
+  revalidateTag(tag);
+  return NextResponse.json({ revalidated: true });
+}
+```
+
+#### Шаг 2: Утилита для воркера
+
+Создана функция `lib/revalidate.ts`:
+
+```typescript
+export async function revalidateCacheFromWorker(tag: string): Promise<boolean> {
+  const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+  const secret = process.env.REVALIDATE_SECRET;
+
+  const response = await fetch(`${baseUrl}/api/revalidate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tag, secret }),
+  });
+
+  return response.ok;
+}
+```
+
+#### Шаг 3: Использование в воркере
+
+В `worker/worker.ts`:
+
+```typescript
+import { revalidateCacheFromWorker } from '@/lib/revalidate';
+
+// После успешного завершения
+await processVideo(videoId, video.userId);
+await revalidateCacheFromWorker('videos').catch(err => 
+  logger.warn('Cache revalidation failed (non-critical)', { error: err })
+);
+
+// После финальной ошибки
+if (!shouldRetry) {
+  await prisma.video.update({
+    where: { videoId },
+    data: { processing: false, failed: true }
+  });
+  await revalidateCacheFromWorker('videos');
+}
+```
+
+## Архитектура
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Client Browser                          │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Next.js Application                        │
+│                                                             │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  Server Actions (app/actions/create.ts)              │  │
+│  │  ✓ Прямой доступ к revalidateTag                     │  │
+│  │  revalidateTag('videos') ──────────────────┐         │  │
+│  └──────────────────────────────────────────────────────┘  │
+│                                                 │           │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  API Route (/api/revalidate)                ◄────────┤  │
+│  │  export async function POST(request) {      │        │  │
+│  │    revalidateTag(tag);                      │        │  │
+│  │  }                                          │        │  │
+│  └──────────────────────────────────────────────────────┘  │
+│                                                 ▲           │
+└─────────────────────────────────────────────────┼───────────┘
+                                                  │
+                                         HTTP POST request
+                                                  │
+┌─────────────────────────────────────────────────┼───────────┐
+│                  Worker Process (worker.ts)     │           │
+│                                                             │
+│  await processVideo();                                      │
+│  await revalidateCacheFromWorker('videos'); ────────────────┘
+│    ↑                                                        │
+│    └─ lib/revalidate.ts: HTTP fetch к /api/revalidate      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Безопасность
+
+### Опциональная защита через secret
+
+Добавьте в `.env`:
+
+```bash
+REVALIDATE_SECRET=your-random-secret-string
+```
+
+API endpoint будет проверять secret перед инвалидацией кэша.
+
+### Почему это безопасно без secret?
+
+1. **Локальный вызов:** В production воркер и Next.js app находятся на одном сервере
+2. **Ограниченная функциональность:** Endpoint только инвалидирует кэш, не изменяет данные
+3. **Rate limiting:** В production рекомендуется добавить rate limiting на уровне nginx/load balancer
+
+## Переменные окружения
+
+```bash
+# Базовый URL приложения (для воркера)
+NEXTAUTH_URL=https://your-domain.com
+
+# Опциональный secret для защиты endpoint
+REVALIDATE_SECRET=your-random-secret
+```
+
+## Преимущества решения
+
+1. ✅ **Немедленное обновление:** Видео появляются в дашборде сразу после создания
+2. ✅ **Работает из воркера:** Обход ограничения Next.js static generation store
+3. ✅ **Отказоустойчивость:** Ошибка инвалидации кэша не прерывает основной процесс
+4. ✅ **Масштабируемость:** Можно использовать для других тегов кэша
+5. ✅ **Простота:** Минимальный код, используем стандартные механизмы Next.js
+
+## Альтернативные решения (не использованы)
+
+### 1. Удаление кэширования
+❌ Плохо для производительности
+
+### 2. On-demand ISR через webhook
+❌ Сложнее, требует внешних сервисов
+
+### 3. WebSocket/Server-Sent Events
+❌ Избыточно для данной задачи
+
+### 4. Уменьшение времени кэширования
+❌ Не решает проблему полностью, увеличивает нагрузку на БД
+
+## Тестирование
+
+1. Создайте новое видео
+2. Сразу после редиректа проверьте дашборд
+3. Видео должно отображаться немедленно (в статусе processing)
+4. После завершения обработки статус должен обновиться автоматически
+
+## Логирование
+
+Воркер логирует результат инвалидации:
+
+```
+[WORKER] DEBUG: Cache revalidated successfully {"tag":"videos"}
+[WORKER] WARN: Cache revalidation failed (non-critical) {"error":"..."}
+```
+
+Ошибки инвалидации не критичны и не прерывают процесс - в худшем случае пользователь увидит видео через 30 секунд или при ручном обновлении.

--- a/lib/revalidate.ts
+++ b/lib/revalidate.ts
@@ -1,0 +1,49 @@
+/**
+ * Утилита для инвалидации кэша из воркера
+ * 
+ * Так как воркер работает вне контекста Next.js, он не может напрямую
+ * использовать revalidateTag. Вместо этого мы делаем HTTP запрос к API endpoint.
+ */
+
+import { logger } from './logger';
+
+/**
+ * Инвалидирует кэш по тегу через API endpoint
+ * 
+ * @param tag - Тег кэша для инвалидации (например, 'videos')
+ * @returns Promise<boolean> - true если успешно, false при ошибке
+ */
+export async function revalidateCacheFromWorker(tag: string): Promise<boolean> {
+  try {
+    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    const secret = process.env.REVALIDATE_SECRET;
+
+    const response = await fetch(`${baseUrl}/api/revalidate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tag, secret }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      logger.warn('Failed to revalidate cache', {
+        tag,
+        status: response.status,
+        error: errorData,
+      });
+      return false;
+    }
+
+    const data = await response.json();
+    logger.debug('Cache revalidated successfully', { tag, data });
+    return true;
+  } catch (error) {
+    logger.error('Error revalidating cache from worker', {
+      tag,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -5,6 +5,7 @@ import { prisma, withRetry } from "@/app/lib/db";
 import { setVideoProgress, deleteVideoProgress, testRedisConnection, getVideoCheckpoint, getNextStep, setRedisInstance } from "@/lib/redis";
 import { createRedisConfig, validateRedisConfig } from "@/lib/redis-config";
 import { workerLogger as logger } from "@/lib/logger";
+import { revalidateCacheFromWorker } from "@/lib/revalidate";
 
 // Функция для определения, стоит ли делать ретрай
 // Проверяет network/timeout/DNS/socket ошибки, избегая маскировки логических багов
@@ -164,6 +165,11 @@ const worker = new Worker('video-processing', async (job: Job) => {
             userId: video.userId
         }).catch(err => logger.warn('Redis progress update failed', { error: err.message }));
 
+        // Инвалидируем кэш видео для обновления дашборда
+        await revalidateCacheFromWorker('videos').catch(err => 
+            logger.warn('Cache revalidation failed (non-critical)', { error: err })
+        );
+
         // Удаляем прогресс через 30 секунд - ЗАКОММЕНТИРОВАНО для экономии Redis запросов
         // TTL автоматически удалит через 1 час (VIDEO_PROGRESS_TTL)
         // setTimeout(() => {
@@ -241,6 +247,11 @@ const worker = new Worker('video-processing', async (job: Job) => {
                         failed: true,
                     }
                 })
+            );
+            
+            // Инвалидируем кэш для отображения failed статуса в дашборде
+            await revalidateCacheFromWorker('videos').catch(err => 
+                logger.warn('Cache revalidation failed (non-critical)', { error: err })
             );
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a cache revalidation API to allow background processing to refresh dashboard data automatically.

* **Bug Fixes**
  * New, completed, failed, or deleted videos now appear on the dashboard immediately without manual refresh.
  * Resolved stale video list caused by unstable caching.
  * Improved redirect behavior so dashboard reflects video changes instantly.

* **Documentation**
  * Added a guide outlining cache revalidation architecture and setup.

* **Chores**
  * Published release 1.6.6 with detailed changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->